### PR TITLE
fix(#77): update server hostname to support IPv6 for Nodejs > 16

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,4 @@
-import {createServer} from '@vue-storefront/middleware';
+import { createServer } from '@vue-storefront/middleware';
 import consola from 'consola';
 import config from '../middleware.config';
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,10 +1,10 @@
-import { createServer } from '@vue-storefront/middleware';
+import {createServer} from '@vue-storefront/middleware';
 import consola from 'consola';
 import config from '../middleware.config';
 
 (async () => {
   const app = await createServer({ integrations: config.integrations });
-  const host = process.argv[2] ?? '0.0.0.0';
+  const host = process.argv[2] ?? '::';
   const port = Number(process.argv[3]) || 4000;
 
   app.listen(port, host, () => {


### PR DESCRIPTION
### Description

---

Refactored host name declaration to support both IPv4 and IPv6 as required by NodeJS > v16.

Change is a single change from `0.0.0.0` to `::` which translates to `everywhere` in IPv6, and is shorthand for `0.0.0.0.0.0.0.0`.

Closing: #77

### Type of change

---

<!--- Please delete options that are not relevant. --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

---

1. Tested / validated change for v16.17.0, and was able to confirm successful client / server start & connection.
2. Tested / validated change for v18.16.0, and was able to confirm successful client / server start & connection. 


### Screenshots

---

![Screenshot 2023-07-24 at 5 21 52 PM](https://github.com/vuestorefront/storefront-next13-boilerplate/assets/21325640/96091cfa-61cc-4a2d-b38e-16a7e78f745f)
![Screenshot 2023-07-24 at 5 23 14 PM](https://github.com/vuestorefront/storefront-next13-boilerplate/assets/21325640/cd5f9ee2-ac50-40f2-bff8-76a40a616c63)


### Checklist:

---

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code

