### PR TITLE
feat(UST-1137): add `@vue-storefront/next`

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Build and publish docker image
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:

--- a/.github/workflows/conventional-pr-name.yml
+++ b/.github/workflows/conventional-pr-name.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           registry-url: https://registrynpm.storefrontcloud.io
 
@@ -31,4 +31,3 @@ jobs:
 
       - name: Run cypress tests
         run: yarn test:e2e:run
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/run-lhci-test.yml
+++ b/.github/workflows/run-lhci-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           registry-url: https://registrynpm.storefrontcloud.io
       - name: Install dependencies

--- a/apps/web/helpers/createGetServerSideProps.ts
+++ b/apps/web/helpers/createGetServerSideProps.ts
@@ -1,0 +1,64 @@
+import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import { DehydratedState, QueryClient, dehydrate } from '@tanstack/react-query';
+import { SSRConfig } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { getSdk } from '~/sdk';
+import { GetServerSideEnhancedContext } from './types';
+
+interface CreateGetServerSidePropsOptions {
+  i18nNamespaces: string[];
+}
+
+type DehydratedOptions = { dehydratedState: DehydratedState };
+type EmptyResponse = void | Promise<void>;
+
+/**
+ * Wraps a `getServerSideProps` function with the following:
+ * - Ensures that the required i18nNamespaces (for example "common", "footer") are loaded
+ *
+ * @param {String[]} options.i18nNamespaces a list of i18n namespaces to load, you can skip
+ * "common", "footer", "message" because they are loaded by default
+ * @param getServerSideProps the original getServerSideProps function which will be wrapped,
+ * you can skip this if you only want to load i18n namespaces
+ */
+export function createGetServerSideProps<TProps extends Record<string, unknown> = Record<string, unknown>>(
+  options: CreateGetServerSidePropsOptions,
+  getServerSideProps?: (
+    context: GetServerSideEnhancedContext,
+  ) => GetServerSidePropsResult<TProps> | Promise<GetServerSidePropsResult<TProps>> | EmptyResponse,
+) {
+  return async function wrappedGetServerSideProps(
+    context: GetServerSidePropsContext,
+  ): Promise<GetServerSidePropsResult<TProps & SSRConfig>> {
+    const i18nNamespaces = [...new Set([...options.i18nNamespaces, 'common', 'footer'])];
+    const fetchTranslations = () => serverSideTranslations(context.locale as string, i18nNamespaces);
+    const sdk = getSdk({ getRequestHeaders: () => context.req.headers });
+    const queryClient = new QueryClient();
+    const enhancedContext: GetServerSideEnhancedContext = { ...context, queryClient, sdk };
+
+    if (getServerSideProps === undefined) {
+      return {
+        props: {
+          ...(await fetchTranslations()),
+          dehydratedState: dehydrate(queryClient),
+        } as TProps & SSRConfig & DehydratedOptions,
+      };
+    }
+
+    const [response, translations] = await Promise.all([getServerSideProps(enhancedContext), fetchTranslations()]);
+    const resolvedResponse = response ?? { props: {} };
+
+    if ('props' in resolvedResponse) {
+      return {
+        ...resolvedResponse,
+        props: {
+          ...resolvedResponse.props,
+          ...translations,
+          ...((resolvedResponse.props as TProps).dehydratedState ? {} : { dehydratedState: dehydrate(queryClient) }),
+        } as TProps & SSRConfig,
+      };
+    }
+
+    return resolvedResponse;
+  };
+}

--- a/apps/web/helpers/index.ts
+++ b/apps/web/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './createGetServerSideProps';

--- a/apps/web/helpers/types.ts
+++ b/apps/web/helpers/types.ts
@@ -1,0 +1,8 @@
+import { GetServerSidePropsContext } from 'next';
+import { QueryClient } from '@tanstack/react-query';
+import { Sdk } from '~/sdk';
+
+export interface GetServerSideEnhancedContext extends GetServerSidePropsContext {
+  queryClient: QueryClient;
+  sdk: Sdk;
+}

--- a/apps/web/hooks/useCart/__tests__/useCart.spec.ts
+++ b/apps/web/hooks/useCart/__tests__/useCart.spec.ts
@@ -1,19 +1,17 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { createWrapper } from '~/jest.utils';
 import { useCart } from '~/hooks';
+import { createWrapper } from '~/jest.utils';
 import { mockCart } from './useCart.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getCart: jest.fn(() => mockCart),
-    },
+const sdk = {
+  commerce: {
+    getCart: jest.fn(() => mockCart),
   },
-}));
+};
 
 describe('useCart', () => {
   it('should return cart', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useCart(), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());

--- a/apps/web/hooks/useCart/useCart.ts
+++ b/apps/web/hooks/useCart/useCart.ts
@@ -1,13 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { SfCart } from '@vue-storefront/unified-data-model';
-import { sdk } from '~/sdk';
-
-const fetchCart = async (): Promise<SfCart> => {
-  return sdk.commerce.getCart();
-};
+import { useSdk } from '~/sdk';
 
 export function useCart() {
-  return useQuery(['cart'], () => fetchCart(), {
+  const sdk = useSdk();
+
+  return useQuery(['cart'], () => sdk.commerce.getCart(), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/hooks/useCartShippingMethods/__tests__/useCartShippingMethods.mock.ts
+++ b/apps/web/hooks/useCartShippingMethods/__tests__/useCartShippingMethods.mock.ts
@@ -1,0 +1,26 @@
+export const mockCartShippingMethods = {
+  methods: [
+    {
+      description: '',
+      estimatedDelivery: 'tomorrow',
+      id: '1',
+      name: 'Standard',
+      price: {
+        amount: 3,
+        currency: 'USD',
+        precisionAmount: '2',
+      },
+    },
+    {
+      description: '',
+      estimatedDelivery: 'tomorrow',
+      id: '2',
+      name: 'Express',
+      price: {
+        amount: 10,
+        currency: 'USD',
+        precisionAmount: '2',
+      },
+    },
+  ],
+};

--- a/apps/web/hooks/useCartShippingMethods/__tests__/useCartShippingMethods.spec.ts
+++ b/apps/web/hooks/useCartShippingMethods/__tests__/useCartShippingMethods.spec.ts
@@ -1,41 +1,21 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useCartShippingMethods } from '~/hooks';
 import { createWrapper } from '~/jest.utils';
+import { mockCartShippingMethods } from './useCartShippingMethods.mock';
+
+const sdk = {
+  commerce: {
+    getShippingMethods: jest.fn(() => mockCartShippingMethods),
+  },
+};
 
 describe('useCartShippingMethods', () => {
   it('should return shipping methods', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useCartShippingMethods(), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());
 
-    expect(result.current.data).toMatchInlineSnapshot(`
-      {
-        "methods": [
-          {
-            "description": "",
-            "estimatedDelivery": "tomorrow",
-            "id": "1",
-            "name": "Standard",
-            "price": {
-              "amount": 3,
-              "currency": "USD",
-              "precisionAmount": "2",
-            },
-          },
-          {
-            "description": "",
-            "estimatedDelivery": "tomorrow",
-            "id": "2",
-            "name": "Express",
-            "price": {
-              "amount": 10,
-              "currency": "USD",
-              "precisionAmount": "2",
-            },
-          },
-        ],
-      }
-    `);
+    expect(result.current.data).toEqual(mockCartShippingMethods);
   });
 });

--- a/apps/web/hooks/useCartShippingMethods/useCartShippingMethods.ts
+++ b/apps/web/hooks/useCartShippingMethods/useCartShippingMethods.ts
@@ -1,13 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { SfShippingMethods } from '@vue-storefront/unified-data-model';
-import { sdk } from '~/sdk';
-
-const fetchShippingMethods = async (): Promise<SfShippingMethods> => {
-  return sdk.commerce.getShippingMethods();
-};
+import { useSdk } from '~/sdk';
 
 export function useCartShippingMethods() {
-  return useQuery(['shippingMethods'], () => fetchShippingMethods(), {
+  const sdk = useSdk();
+
+  return useQuery(['shippingMethods'], () => sdk.commerce.getShippingMethods(), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/hooks/useContent/__tests__/useContent.spec.ts
+++ b/apps/web/hooks/useContent/__tests__/useContent.spec.ts
@@ -1,33 +1,30 @@
 import { QueryClient } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { createWrapper } from '~/jest.utils';
+import { createGetServerSidePropsContext, createWrapper } from '~/jest.utils';
 import { useContent, prefetchContent } from '../useContent';
 import { mockContent } from './useContent.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getContent: jest.fn(() => mockContent),
-    }
-  }
-}));
-
+const sdk = {
+  commerce: {
+    getContent: jest.fn(() => mockContent),
+  },
+};
 
 describe('prefetchProduct', () => {
   it('should return queryClient', async () => {
-    const client = await prefetchContent('mock-url');
-    
-    expect(client).toBeInstanceOf(QueryClient);
+    const response = await prefetchContent(createGetServerSidePropsContext({ sdk }), 'mock-url');
+
+    expect(response).toEqual(mockContent);
   });
 });
 
 describe('useContent', () => {
   it('should return content', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useContent('mock-url'), { wrapper });
-    
+
     await waitFor(() => expect(result.current.data).not.toBeUndefined());
-    
+
     expect(result.current.data).toMatchInlineSnapshot(`
       [
         {

--- a/apps/web/hooks/useContent/useContent.ts
+++ b/apps/web/hooks/useContent/useContent.ts
@@ -1,9 +1,9 @@
 import { QueryClient, useQuery } from '@tanstack/react-query';
-import { sdk } from '~/sdk';
+import { getSdk, useSdk } from '~/sdk';
 
 export async function prefetchContent(url: string): Promise<QueryClient> {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['content', url], () => sdk.commerce.getContent({ url }));
+  await queryClient.prefetchQuery(['content', url], () => getSdk().commerce.getContent({ url }));
 
   return queryClient;
 }
@@ -14,6 +14,8 @@ export async function prefetchContent(url: string): Promise<QueryClient> {
  */
 
 export function useContent<TFields>(url: string) {
+  const sdk = useSdk();
+
   return useQuery(['content', url], () => sdk.commerce.getContent<TFields>({ url }), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/apps/web/hooks/useContent/useContent.ts
+++ b/apps/web/hooks/useContent/useContent.ts
@@ -1,11 +1,13 @@
-import { QueryClient, useQuery } from '@tanstack/react-query';
-import { getSdk, useSdk } from '~/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { GetServerSideEnhancedContext } from '~/helpers/types';
+import { useSdk } from '~/sdk';
 
-export async function prefetchContent(url: string): Promise<QueryClient> {
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['content', url], () => getSdk().commerce.getContent({ url }));
+export async function prefetchContent(context: GetServerSideEnhancedContext, url: string) {
+  const { queryClient, sdk } = context;
+  const content = await sdk.commerce.getContent({ url });
+  queryClient.setQueryData(['content', url], content);
 
-  return queryClient;
+  return content;
 }
 
 /**

--- a/apps/web/hooks/useProduct/__tests__/useProduct.spec.ts
+++ b/apps/web/hooks/useProduct/__tests__/useProduct.spec.ts
@@ -1,28 +1,25 @@
-import { QueryClient } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { createWrapper } from '~/jest.utils';
-import { useProduct, prefetchProduct } from '../useProduct';
+import { createGetServerSidePropsContext, createWrapper } from '~/jest.utils';
+import { prefetchProduct, useProduct } from '../useProduct';
 import { mockProduct } from './useProduct.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getProduct: jest.fn(() => mockProduct),
-    },
+const sdk = {
+  commerce: {
+    getProduct: jest.fn(() => mockProduct),
   },
-}));
+};
 
 describe('prefetchProduct', () => {
   it('should return queryClient', async () => {
-    const client = await prefetchProduct('mock-slug');
+    const response = await prefetchProduct(createGetServerSidePropsContext({ sdk }), 'mock-slug');
 
-    expect(client).toBeInstanceOf(QueryClient);
+    expect(response).toEqual(mockProduct);
   });
 });
 
 describe('useProduct', () => {
   it('should return product reviews', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useProduct('mock-slug'), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());

--- a/apps/web/hooks/useProduct/useProduct.ts
+++ b/apps/web/hooks/useProduct/useProduct.ts
@@ -1,14 +1,9 @@
 import { QueryClient, useQuery } from '@tanstack/react-query';
-import { SfProduct } from '@vue-storefront/unified-data-model';
-import { sdk } from '~/sdk';
-
-const fetchProduct = async (slug: string): Promise<SfProduct> => {
-  return sdk.commerce.getProduct({ slug });
-};
+import { getSdk, useSdk } from '~/sdk';
 
 export async function prefetchProduct(slug: string): Promise<QueryClient> {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['product', slug], () => fetchProduct(slug));
+  await queryClient.prefetchQuery(['product', slug], () => getSdk().commerce.getProduct({ slug }));
 
   return queryClient;
 }
@@ -18,7 +13,9 @@ export async function prefetchProduct(slug: string): Promise<QueryClient> {
  * @param {string} slug Product slug
  */
 export function useProduct(slug: string) {
-  return useQuery(['product', slug], () => fetchProduct(slug), {
+  const sdk = useSdk();
+
+  return useQuery(['product', slug], () => sdk.commerce.getProduct({ slug }), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/hooks/useProduct/useProduct.ts
+++ b/apps/web/hooks/useProduct/useProduct.ts
@@ -1,11 +1,14 @@
-import { QueryClient, useQuery } from '@tanstack/react-query';
-import { getSdk, useSdk } from '~/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { SfProduct } from '@vue-storefront/unified-data-model';
+import { GetServerSideEnhancedContext } from '~/helpers/types';
+import { useSdk } from '~/sdk';
 
-export async function prefetchProduct(slug: string): Promise<QueryClient> {
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['product', slug], () => getSdk().commerce.getProduct({ slug }));
+export async function prefetchProduct(context: GetServerSideEnhancedContext, slug: string): Promise<SfProduct> {
+  const { queryClient, sdk } = context;
+  const product = await sdk.commerce.getProduct({ slug });
+  queryClient.setQueryData(['product', slug], product);
 
-  return queryClient;
+  return product;
 }
 
 /**

--- a/apps/web/hooks/useProductAttribute/__tests__/useProductAttribute.spec.ts
+++ b/apps/web/hooks/useProductAttribute/__tests__/useProductAttribute.spec.ts
@@ -1,12 +1,10 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { createWrapper } from '~/jest.utils';
+import { renderHook } from '@testing-library/react';
 import { useProductAttribute } from '../useProductAttribute';
 import { mockProduct } from './useProduct.mock';
 
 describe('useProductAttribute', () => {
   it('should return product attributes', async () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useProductAttribute(mockProduct, ['attribute']), { wrapper });
+    const { result } = renderHook(() => useProductAttribute(mockProduct, ['attribute']));
 
     const attributeList = result.current.getAttributeList('attribute');
     const attributeValue = result.current.getAttribute('attribute');

--- a/apps/web/hooks/useProductBreadcrumbs/__tests__/useProductBreadcrumbs.spec.ts
+++ b/apps/web/hooks/useProductBreadcrumbs/__tests__/useProductBreadcrumbs.spec.ts
@@ -1,21 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { SfProduct } from '@vue-storefront/unified-data-model';
 import { useProductBreadcrumbs } from '~/hooks';
-import { createWrapper } from '~/jest.utils';
-
-afterEach(() => {
-  jest.clearAllMocks();
-});
 
 describe('useProductBreadcrumbs', () => {
   it('should return breadcrumbs for product', () => {
-    const wrapper = createWrapper();
-
     const productMock = {
       name: 'product-name',
     } as SfProduct;
 
-    const { result } = renderHook(() => useProductBreadcrumbs(productMock), { wrapper });
+    const { result } = renderHook(() => useProductBreadcrumbs(productMock));
 
     expect(result.current.breadcrumbs).toEqual([
       {

--- a/apps/web/hooks/useProductRecommended/__tests__/useProductRecommended.spec.ts
+++ b/apps/web/hooks/useProductRecommended/__tests__/useProductRecommended.spec.ts
@@ -3,17 +3,15 @@ import { createWrapper } from '~/jest.utils';
 import { useProductRecommended } from '../useProductRecommended';
 import { mockProducts } from './useProductRecommended.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getProductRecommended: jest.fn(() => mockProducts),
-    },
+const sdk = {
+  commerce: {
+    getProductRecommended: jest.fn(() => mockProducts),
   },
-}));
+};
 
 describe('useProductRecommended', () => {
   it('should return product reviews', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useProductRecommended('mock-slug'), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());

--- a/apps/web/hooks/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/hooks/useProductRecommended/useProductRecommended.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { SfProduct } from '@vue-storefront/unified-data-model';
-import { sdk } from '~/sdk';
-
-const fetchProductRecommended = async (slug: string): Promise<SfProduct[]> => {
-  return sdk.commerce.getProductRecommended({ slug });
-};
+import { useSdk } from '~/sdk';
 
 /**
  * Hook for getting recommended products data
  * @param {string} slug Product slug
  */
 export function useProductRecommended(slug: string) {
-  return useQuery(['recommended', slug], () => fetchProductRecommended(slug), {
+  const sdk = useSdk();
+
+  return useQuery(['recommended', slug], () => sdk.commerce.getProductRecommended({ slug }), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/hooks/useProductReviews/__tests__/useProductReviews.spec.ts
+++ b/apps/web/hooks/useProductReviews/__tests__/useProductReviews.spec.ts
@@ -3,17 +3,15 @@ import { createWrapper } from '~/jest.utils';
 import { useProductReviews } from '../useProductReviews';
 import { mockProducts } from './useProductReviews.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getProductReviews: jest.fn(() => mockProducts),
-    },
+const sdk = {
+  commerce: {
+    getProductReviews: jest.fn(() => mockProducts),
   },
-}));
+};
 
 describe('useProductReviews', () => {
   it('should return product reviews', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useProductReviews('mock-slug'), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());

--- a/apps/web/hooks/useProductReviews/useProductReviews.ts
+++ b/apps/web/hooks/useProductReviews/useProductReviews.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { SfProductReview } from '@vue-storefront/unified-data-model';
-import { sdk } from '~/sdk';
-
-const fetchProductReviews = async (slug: string): Promise<SfProductReview[]> => {
-  return sdk.commerce.getProductReviews({ slug });
-};
+import { useSdk } from '~/sdk';
 
 /**
  * Hook for getting product reviews
  * @param {string} slug Product slug
  */
 export function useProductReviews(slug: string) {
-  return useQuery(['reviews', slug], () => fetchProductReviews(slug), {
+  const sdk = useSdk();
+
+  return useQuery(['reviews', slug], () => sdk.commerce.getProductReviews({ slug }), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/hooks/useProducts/__tests__/useProducts.mock.ts
+++ b/apps/web/hooks/useProducts/__tests__/useProducts.mock.ts
@@ -28,6 +28,7 @@ export const mockProducts: GetProducts = {
         average: 3,
         count: 26,
       },
+      quantityLimit: 10,
     },
   ],
   pagination: {

--- a/apps/web/hooks/useProducts/__tests__/useProducts.spec.ts
+++ b/apps/web/hooks/useProducts/__tests__/useProducts.spec.ts
@@ -1,28 +1,25 @@
-import { QueryClient } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { createWrapper } from '~/jest.utils';
-import { useProducts, prefetchProducts } from '../useProducts';
+import { createGetServerSidePropsContext, createWrapper } from '~/jest.utils';
+import { prefetchProducts, useProducts } from '../useProducts';
 import { mockProducts } from './useProducts.mock';
 
-jest.mock('~/sdk', () => ({
-  sdk: {
-    commerce: {
-      getProducts: jest.fn(() => mockProducts),
-    },
+const sdk = {
+  commerce: {
+    getProducts: jest.fn(() => mockProducts),
   },
-}));
+};
 
 describe('prefetchProducts', () => {
   it('should return queryClient', async () => {
-    const client = await prefetchProducts();
+    const response = await prefetchProducts(createGetServerSidePropsContext({ sdk }));
 
-    expect(client).toBeInstanceOf(QueryClient);
+    expect(response).toEqual(mockProducts);
   });
 });
 
 describe('useProducts', () => {
   it('should return products', async () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ sdk });
     const { result } = renderHook(() => useProducts(), { wrapper });
 
     await waitFor(() => expect(result.current.data).not.toBeUndefined());
@@ -82,6 +79,7 @@ describe('useProducts', () => {
               "alt": "Athletic mens walking sneakers",
               "url": "/images/product.webp",
             },
+            "quantityLimit": 10,
             "rating": {
               "average": 3,
               "count": 26,

--- a/apps/web/hooks/useProducts/useProducts.ts
+++ b/apps/web/hooks/useProducts/useProducts.ts
@@ -1,11 +1,14 @@
-import { QueryClient, useQuery } from '@tanstack/react-query';
-import { getSdk, useSdk } from '~/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { GetProducts } from '@vue-storefront/storefront-boilerplate-sdk';
+import { GetServerSideEnhancedContext } from '~/helpers/types';
+import { useSdk } from '~/sdk';
 
-export async function prefetchProducts(): Promise<QueryClient> {
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['products'], () => getSdk().commerce.getProducts());
+export async function prefetchProducts(context: GetServerSideEnhancedContext): Promise<GetProducts> {
+  const { queryClient, sdk } = context;
+  const products = await sdk.commerce.getProducts();
+  queryClient.setQueryData(['products'], products);
 
-  return queryClient;
+  return products;
 }
 
 /**

--- a/apps/web/hooks/useProducts/useProducts.ts
+++ b/apps/web/hooks/useProducts/useProducts.ts
@@ -1,14 +1,9 @@
 import { QueryClient, useQuery } from '@tanstack/react-query';
-import type { GetProducts } from '@vue-storefront/storefront-boilerplate-sdk';
-import { sdk } from '~/sdk';
-
-const fetchProducts = async (): Promise<GetProducts> => {
-  return sdk.commerce.getProducts();
-};
+import { getSdk, useSdk } from '~/sdk';
 
 export async function prefetchProducts(): Promise<QueryClient> {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['products'], () => fetchProducts());
+  await queryClient.prefetchQuery(['products'], () => getSdk().commerce.getProducts());
 
   return queryClient;
 }
@@ -17,7 +12,9 @@ export async function prefetchProducts(): Promise<QueryClient> {
  * Hook for getting products catalog data
  */
 export function useProducts() {
-  return useQuery(['products'], () => fetchProducts(), {
+  const sdk = useSdk();
+
+  return useQuery(['products'], () => sdk.commerce.getProducts(), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -34,3 +34,8 @@ window.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+jest.mock('~/sdk', () => ({
+  ...jest.requireActual('~/sdk'),
+  useSdk: jest.fn(),
+}));

--- a/apps/web/jest.utils.tsx
+++ b/apps/web/jest.utils.tsx
@@ -1,9 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /* eslint-disable react/display-name */
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 /* eslint-disable no-console */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GetServerSideEnhancedContext } from './helpers/types';
+import { useSdk } from './sdk';
 
 export const createTestQueryClient = () =>
   new QueryClient({
@@ -20,8 +24,27 @@ export const createTestQueryClient = () =>
     },
   });
 
-export const createWrapper = () => {
+interface CreateWrapperParams {
+  sdk?: any;
+}
+
+export const createWrapper = ({ sdk }: CreateWrapperParams = {}) => {
   const testQueryClient = createTestQueryClient();
+  jest.mocked(useSdk).mockReturnValue(sdk ?? {});
 
   return ({ children }: any) => <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>;
 };
+
+interface CreateGetServerSidePropsContextParams {
+  sdk: any;
+  queryClient?: QueryClient;
+}
+
+export const createGetServerSidePropsContext = ({
+  sdk,
+  queryClient = createTestQueryClient(),
+}: CreateGetServerSidePropsContextParams) =>
+  ({
+    sdk,
+    queryClient,
+  } as GetServerSideEnhancedContext);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@storefront-ui/react": "~2.2.0",
     "@storefront-ui/shared": "~2.2.0",
     "@tanstack/react-query": "^4.29.5",
+    "@vue-storefront/next": "~1.0.0",
     "@vue-storefront/sdk": "~1.0.1",
     "@vue-storefront/storefront-boilerplate-sdk": "~0.1.0",
     "classnames": "^2.3.2",

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -5,6 +5,7 @@ import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import classNames from 'classnames';
 import { appWithTranslation } from 'next-i18next';
+import { SdkProvider } from '~/sdk';
 import { fontBody, fontHeadings } from '~/styles/fonts';
 import '~/styles/main.scss';
 
@@ -22,17 +23,19 @@ function App({ Component, pageProps }: AppProps) {
   );
   return (
     <QueryClientProvider client={queryClient}>
-      <Head>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
-        <meta name="description" content="VSF x Next.js (Boilerplate)" />
-        <title>Vue Storefront React Boilerplate</title>
-      </Head>
-      <Hydrate state={pageProps.dehydratedState}>
-        <div className={classNames(fontHeadings.variable, fontBody.variable, 'font-body')}>
-          <Component {...pageProps} />
-        </div>
-      </Hydrate>
-      <ReactQueryDevtools />
+      <SdkProvider>
+        <Head>
+          <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+          <meta name="description" content="VSF x Next.js (Boilerplate)" />
+          <title>Vue Storefront React Boilerplate</title>
+        </Head>
+        <Hydrate state={pageProps.dehydratedState}>
+          <div className={classNames(fontHeadings.variable, fontBody.variable, 'font-body')}>
+            <Component {...pageProps} />
+          </div>
+        </Hydrate>
+        <ReactQueryDevtools />
+      </SdkProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/web/pages/cart.tsx
+++ b/apps/web/pages/cart.tsx
@@ -1,19 +1,11 @@
-import { GetServerSidePropsContext } from 'next';
 import { useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { CartPageContent } from '~/components';
+import { createGetServerSideProps } from '~/helpers';
 import { CheckoutLayout } from '~/layouts';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
-
-  return {
-    props: {
-      key: 'cart',
-      ...(await serverSideTranslations(locale as string, ['cart', 'common', 'footer', 'product'])),
-    },
-  };
-}
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: ['cart', 'product'] }, (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+});
 
 export function CartPage() {
   const { t } = useTranslation('cart');

--- a/apps/web/pages/category.tsx
+++ b/apps/web/pages/category.tsx
@@ -1,7 +1,4 @@
-import { GetServerSidePropsContext } from 'next';
-import { dehydrate } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import {
   CategoryPageContent,
   CategoryTree,
@@ -10,28 +7,22 @@ import {
   Breadcrumb,
   CategoryTreeItem,
 } from '~/components';
+import { createGetServerSideProps } from '~/helpers';
 import { prefetchProducts, useProducts } from '~/hooks';
 import { DefaultLayout } from '~/layouts';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: ['category'] }, async (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+  const products = await prefetchProducts(context);
 
-  const queryClient = await prefetchProducts();
-  const data = queryClient.getQueryData(['products']);
-
-  if (!data) {
+  if (!products) {
     return {
       notFound: true,
     };
   }
 
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-      ...(await serverSideTranslations(locale as string, ['common', 'footer', 'category'])),
-    },
-  };
-}
+  return { props: {} };
+});
 
 export default function CategoryPage() {
   const { t } = useTranslation('category');

--- a/apps/web/pages/checkout.tsx
+++ b/apps/web/pages/checkout.tsx
@@ -1,8 +1,6 @@
-import { GetServerSidePropsContext } from 'next';
 import Link from 'next/link';
 import { SfButton, SfLink } from '@storefront-ui/react';
 import { Trans, useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import {
   Divider,
   OrderSummary,
@@ -11,19 +9,16 @@ import {
   ContactInformation,
   ShippingMethod,
 } from '~/components';
+import { createGetServerSideProps } from '~/helpers';
 import { useCart } from '~/hooks';
 import { CheckoutLayout } from '~/layouts';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
-
-  return {
-    props: {
-      key: 'checkout',
-      ...(await serverSideTranslations(locale as string, ['cart', 'checkout', 'common', 'footer', 'address'])),
-    },
-  };
-}
+export const getServerSideProps = createGetServerSideProps(
+  { i18nNamespaces: ['cart', 'checkout', 'address'] },
+  async (context) => {
+    context.res.setHeader('Cache-Control', 'no-cache');
+  },
+);
 
 export default function Checkout() {
   const { t } = useTranslation('checkout');

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,32 +1,23 @@
 import { Fragment } from 'react';
-import { GetServerSidePropsContext } from 'next';
-import { dehydrate } from '@tanstack/react-query';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { RenderContent } from '~/components';
+import { createGetServerSideProps } from '~/helpers';
 import { useContent, prefetchContent, ContentDynamicPage } from '~/hooks';
 import { DefaultLayout } from '~/layouts';
 
 const contentUrl = 'home-page';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: [] }, async (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+  const content = await prefetchContent(context, contentUrl);
 
-  const queryClient = await prefetchContent(contentUrl);
-  const data = queryClient.getQueryData(['content', contentUrl]);
-
-  if (!data) {
+  if (!content) {
     return {
       notFound: true,
     };
   }
 
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-      ...(await serverSideTranslations(locale as string, ['common', 'footer'])),
-    },
-  };
-}
+  return { props: {} };
+});
 
 export default function Home() {
   const { data: content } = useContent<ContentDynamicPage>(contentUrl);

--- a/apps/web/pages/order/failed.tsx
+++ b/apps/web/pages/order/failed.tsx
@@ -1,22 +1,14 @@
-import { GetServerSidePropsContext } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { SfButton, SfIconArrowBack } from '@storefront-ui/react';
 import { Trans, useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { createGetServerSideProps } from '~/helpers';
 import { OrderLayout } from '~/layouts';
 import somethingWentWrongImage from '~/public/images/something-went-wrong.svg';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
-
-  return {
-    props: {
-      key: 'order',
-      ...(await serverSideTranslations(locale as string, ['common', 'footer', 'order'])),
-    },
-  };
-}
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: ['order'] }, async (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+});
 
 export function OrderFailedPage() {
   const { t } = useTranslation('order');

--- a/apps/web/pages/order/success.tsx
+++ b/apps/web/pages/order/success.tsx
@@ -1,22 +1,14 @@
-import { GetServerSidePropsContext } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { SfButton } from '@storefront-ui/react';
 import { Trans, useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { createGetServerSideProps } from '~/helpers';
 import { OrderLayout } from '~/layouts';
 import orderSuccessImage from '~/public/images/order-success.svg';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
-
-  return {
-    props: {
-      key: 'order',
-      ...(await serverSideTranslations(locale as string, ['common', 'footer', 'order'])),
-    },
-  };
-}
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: ['order'] }, async (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+});
 
 export function OrderSuccessPage() {
   const { t } = useTranslation(['order', 'checkout']);

--- a/apps/web/pages/search.tsx
+++ b/apps/web/pages/search.tsx
@@ -1,31 +1,22 @@
-import { GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
-import { dehydrate } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { CategoryPageContent, CategorySorting, CategoryFilters } from '~/components';
+import { CategoryFilters, CategoryPageContent, CategorySorting } from '~/components';
+import { createGetServerSideProps } from '~/helpers';
 import { prefetchProducts, useProducts } from '~/hooks';
 import { DefaultLayout } from '~/layouts';
 
-export async function getServerSideProps({ res, locale }: GetServerSidePropsContext) {
-  res.setHeader('Cache-Control', 'no-cache');
+export const getServerSideProps = createGetServerSideProps({ i18nNamespaces: ['category'] }, async (context) => {
+  context.res.setHeader('Cache-Control', 'no-cache');
+  const products = await prefetchProducts(context);
 
-  const queryClient = await prefetchProducts();
-  const data = queryClient.getQueryData(['products']);
-
-  if (!data) {
+  if (!products) {
     return {
       notFound: true,
     };
   }
 
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-      ...(await serverSideTranslations(locale as string, ['common', 'footer', 'category'])),
-    },
-  };
-}
+  return { props: {} };
+});
 
 export default function SearchPage() {
   const { t } = useTranslation('category');

--- a/apps/web/sdk/SdkProvider.tsx
+++ b/apps/web/sdk/SdkProvider.tsx
@@ -1,0 +1,4 @@
+import { createSdkContext } from '@vue-storefront/next/client';
+import { getSdk } from './sdk.config';
+
+export const [SdkProvider, useSdk] = createSdkContext(getSdk());

--- a/apps/web/sdk/index.ts
+++ b/apps/web/sdk/index.ts
@@ -1,8 +1,2 @@
-import { initSDK, buildModule } from '@vue-storefront/sdk';
-import { type SdkModule, sdkModule } from '@vue-storefront/storefront-boilerplate-sdk';
-
-const sdkConfig = {
-  commerce: buildModule<SdkModule>(sdkModule),
-};
-
-export const sdk = initSDK<typeof sdkConfig>(sdkConfig);
+export * from './SdkProvider';
+export * from './sdk.config';

--- a/apps/web/sdk/sdk.config.ts
+++ b/apps/web/sdk/sdk.config.ts
@@ -10,3 +10,5 @@ const options: CreateSdkOptions = {
 export const { getSdk } = createSdk(options, ({ buildModule }) => ({
   commerce: buildModule<SdkModule>(sdkModule),
 }));
+
+export type Sdk = ReturnType<typeof getSdk>;

--- a/apps/web/sdk/sdk.config.ts
+++ b/apps/web/sdk/sdk.config.ts
@@ -1,0 +1,12 @@
+import { CreateSdkOptions, createSdk } from '@vue-storefront/next';
+import { SdkModule, sdkModule } from '@vue-storefront/storefront-boilerplate-sdk';
+
+const options: CreateSdkOptions = {
+  middleware: {
+    apiUrl: 'http://localhost:4000',
+  },
+};
+
+export const { getSdk } = createSdk(options, ({ buildModule }) => ({
+  commerce: buildModule<SdkModule>(sdkModule),
+}));

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "cypress": "^13.2.0"
   },
   "engines": {
-    "npm": ">=8.0.0",
-    "node": ">=16.16.0"
+    "npm": ">=9.0.0",
+    "node": ">=18.0.0"
   },
   "packageManager": "yarn@1.22.10",
   "config": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vsf/react-boilerplate",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "license": "MIT",
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,11 @@
     helmet "^5.1.1"
     rimraf "^4.1.2"
 
+"@vue-storefront/next@~1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@vue-storefront/next/-/next-1.0.0.tgz#122ecd23288a09792f80f99069a12cf5b5d013eb"
+  integrity sha512-MAF3JyyzIKCgtoVgMbAj1OPf4LPzDfFrcr85zOxiwRmAFpy+LBLR4XZLUxwpBtgBTP93jKhg920YxhYK/WKstg==
+
 "@vue-storefront/sdk@~1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@vue-storefront/sdk/-/sdk-1.0.1.tgz#ed42e5ad76a0b17132edb515a484b10ab2dc1395"


### PR DESCRIPTION
### Description

[UST-1137](https://vsf.atlassian.net/browse/UST-1137)

- Added `@vue-storefront/next` package and used it for the sdk initialization
- Added `createGetServerSideProps`, same  as in `unified-storefronts`
- Upgraded Node.js engine to v18+

---

### Type of change

---

<!--- Please delete options that are not relevant. --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

---

_none_

<!--- Please describe the tests that you ran to verify your changes. --->

### Screenshots

---

_none_

<!--- Please provide screenshots if this PR is related to the UI changes. --->

### Checklist:

---

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code


[UST-1137]: https://vsf.atlassian.net/browse/UST-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ